### PR TITLE
Use prevState to change counter instead of relying on state

### DIFF
--- a/src/Counter.js
+++ b/src/Counter.js
@@ -65,7 +65,7 @@ export default class Counter extends React.Component {
    * care to display the appropriate error message if the update fails.
    */
   increment() {
-    this.setState({ count: this.state.count + 1 });
+    this.setState((prevState) => ({ count: prevState.count + 1 }) );
     counterIncrement();
   }
 


### PR DESCRIPTION
As per https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous - use the function-accepting form of this.setState when relying on the existing state to calculate future value.